### PR TITLE
Update title to display ZIP code when weather data is loaded

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,15 @@
 import { RefreshButton } from './RefreshButton'
 import { ZipInput } from './ZipInput'
+import { useWeatherStore } from '../stores/weatherStore'
 
 export function Header() {
+  const { currentZipCode, weatherData } = useWeatherStore()
+
+  // Display ZIP code in title only when weather data is loaded
+  const displayTitle = weatherData && currentZipCode
+    ? `HAUS Weather - ${currentZipCode}`
+    : 'HAUS Weather Station'
+
   return (
     <header className="sticky top-0 z-40 w-full border-b border-white/20 dark:border-white/10 bg-white/10 dark:bg-black/20 backdrop-blur-md shadow-glass">
       <div className="container mx-auto px-4 py-4">
@@ -12,7 +20,7 @@ export function Header() {
             <div className="flex items-center gap-2">
               <RefreshButton />
               <h1 className="flex-1 text-center text-2xl font-bold">
-                HAUS Weather Station
+                {displayTitle}
               </h1>
             </div>
 
@@ -30,7 +38,7 @@ export function Header() {
             </div>
 
             {/* Center: Title */}
-            <h1 className="text-3xl font-bold">HAUS Weather Station</h1>
+            <h1 className="text-3xl font-bold">{displayTitle}</h1>
 
             {/* Right: ZIP input */}
             <div className="min-w-[280px]">


### PR DESCRIPTION
## Summary
- Modified `Header` component to display ZIP code in title when weather data is loaded
- Title changes from "HAUS Weather Station" to "HAUS Weather - {ZIP}" (e.g., "HAUS Weather - 75454")
- Falls back to "HAUS Weather Station" when no weather data is displayed

## Implementation
- Added `useWeatherStore` hook to access `currentZipCode` and `weatherData`
- Conditionally renders title based on presence of weather data
- Works on both mobile and desktop layouts

## Test Plan
- [x] Frontend type check passes
- [x] All 829 frontend tests pass
- [x] Backend type check passes
- [x] All 179 backend tests pass
- [x] Title displays ZIP code when weather data is loaded
- [x] Title shows default text when no weather data

🤖 Generated with [Claude Code](https://claude.com/claude-code)